### PR TITLE
Use Git config value for the color option

### DIFF
--- a/git-shame
+++ b/git-shame
@@ -2,8 +2,37 @@
 
 require "optparse"
 
+color_value = nil
+
+def get_setting(name)
+  IO.popen("git config --get " + name) { |pipe|
+    return pipe.read.strip
+  }
+end
+
+['color.shame', 'color.ui'].each { |name|
+  setting = get_setting name
+
+  puts name, setting
+  case setting
+  when 'always'
+    color_value = true
+  when 'false', 'never'
+    color_value = false
+  when 'auto', 'true'
+    color_value = STDOUT.tty?
+  when ''
+    next
+  else
+    puts 'Unknown color setting "' + setting + '" for "' + name + '"; falling back to "auto"'
+    color_value = STDOUT.tty?
+  end
+
+  break
+}
+
 options = {
-  color: STDOUT.tty?,
+  color: color_value,
   remote: "origin",
   show_commands: false,
   show_merged: true,

--- a/git-shame.1
+++ b/git-shame.1
@@ -21,7 +21,7 @@ Projects can accumulate a significant number of remote topic branches\. Which ar
 \fB\-\-color\fR
 .
 .IP
-Colorful output\. This is automatically set when output is a TTY and the \fIcolored\fR gem is installed\.
+Colorful output\. This is automatically set when output is a TTY and the \fIcolored\fR gem is installed\. If not specified and the Git config value \fcolor.shame\f or \fcolor.ui\f is set, use that as a default value.
 .
 .IP "\(bu" 4
 \fB\-\-no\-color\fR

--- a/git-shame.1.ronn
+++ b/git-shame.1.ronn
@@ -17,7 +17,9 @@ Which are active? Which are safe to delete? Who "owns" them?
 * `--color`
 
   Colorful output. This is automatically set when output is a TTY and
-  the _colored_ gem is installed.
+  the _colored_ gem is installed. If not specified and the Git config
+  value `color.shame` or `color.ui` is set, use that as a default
+  value.
 
 * `--no-color`
 


### PR DESCRIPTION
Instead of relying solely on the terminal, use the Git config value `color.shame` (falling back to
`color.ui`) as a default.